### PR TITLE
improve pipeline(ingest_docs and data_gen) reliability 

### DIFF
--- a/configs/vicuna_13b.yaml
+++ b/configs/vicuna_13b.yaml
@@ -1,4 +1,4 @@
-GENERATE: True #Turn off if you don't want to generate the data
+GENERATE: False #Turn off if you don't want to generate the data
 API_DOCS: https://developers.notion.com/reference  
 DEPTH_CRAWLING: 1 #0 if your API website is long and not hierarchical for example like polygon.io. Otherwise, feel free to set, it might take much longer if your webiste has many children.
 SUMMARIZE_DOCS: True

--- a/configs/vicuna_13b.yaml
+++ b/configs/vicuna_13b.yaml
@@ -1,4 +1,4 @@
-GENERATE: False #Turn off if you don't want to generate the data
+GENERATE: True #Turn off if you don't want to generate the data
 API_DOCS: https://developers.notion.com/reference  
 DEPTH_CRAWLING: 1 #0 if your API website is long and not hierarchical for example like polygon.io. Otherwise, feel free to set, it might take much longer if your webiste has many children.
 SUMMARIZE_DOCS: True

--- a/environment.yaml
+++ b/environment.yaml
@@ -34,4 +34,5 @@ dependencies:
     - EdgeGPT
     - fake_useragent
     - tiktoken
+    - luigi
 

--- a/ingest_docs.py
+++ b/ingest_docs.py
@@ -316,15 +316,18 @@ class IngestDocumentsTask(luigi.Task):
     logger = logging.getLogger(__name__)
 
     def output(self):
-        return luigi.LocalTarget("assets/documents_{}.pkl".format(self.task_id), luigi.LocalTarget("assets/docs_for_summary_{}.pkl".format(self.task_id)))
+        return {
+                'documents': luigi.LocalTarget("assets/documents_{}.pkl".format(self.task_id)),
+                'docs_for_summary': luigi.LocalTarget("assets/docs_for_summary_{}.pkl".format(self.task_id))
+                } 
 
     def run(self):
         self.task_id  = luigi.task.task_id_str(self.get_task_family(), self.to_str_params())
         self.logger.info(self.task_id)
         docs, docs_for_summary = ingest_docs(self.url_docs, self.recursive_depth, logger=self.logger)
-        with self.output()[0].open("wb") as f:
+        with self.output()['documents'].open("wb") as f:
             pickle.dump(docs, f)
-        with self.output()[1].open("wb") as f:
+        with self.output()['docs_for_summary'].open("wb") as f:
             pickle.dump(docs_for_summary, f)
 
 
@@ -347,6 +350,7 @@ class SaveVectorStoreTask(luigi.Task):
 
         with self.output().open("wb") as f:
             pickle.dump(vectorstore, f)
+
 
 if __name__ == "__main__":
     luigi.build([SaveVectorStoreTask("https://developers.notion.com/reference/create-a-token", recursive_depth=0)], local_scheduler=True)

--- a/ingest_docs.py
+++ b/ingest_docs.py
@@ -368,8 +368,8 @@ class IngestDocs(luigi.Task):
 
     def requires(self):
         return {
-            'ingest': IngestDocumentsTask(url_docs=self.url_docs, recursive_depth=self.recursive_depth),
-            'save': SaveVectorStoreTask(url_docs=self.url_docs, recursive_depth=self.recursive_depth)
+            'IngestDocumentsTask': IngestDocumentsTask(url_docs=self.url_docs, recursive_depth=self.recursive_depth),
+            'SaveVectorStoreTask': SaveVectorStoreTask(url_docs=self.url_docs, recursive_depth=self.recursive_depth)
         }
 
     def run(self):

--- a/ingest_docs.py
+++ b/ingest_docs.py
@@ -13,6 +13,7 @@ from selenium import webdriver
 from selenium.webdriver.firefox.service import Service as FirefoxService
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
+from selenium.common.exceptions import WebDriverException, InvalidSessionIdException
 import contextlib
 import lxml.html as LH
 import lxml.html.clean as clean
@@ -22,6 +23,7 @@ import re
 import tqdm
 import time
 import luigi
+from luigi.worker import Worker
 import logging
 from luigi.util import inherits
 
@@ -167,6 +169,7 @@ class APIReferenceLoader(WebBaseLoader):
                     texts.append(words)
             return " ".join(texts)
 
+
     def scrape_structured_elements(self, url):
         """
         Scrape the structured elements of the page using text-based web browser Elinks.
@@ -289,17 +292,22 @@ def ingest_docs(url_docs: str, recursive_depth: int = 1, return_summary: bool = 
     logger.info(f"Crawling {docs_link} ...")
     # Iterate over the collected links
     for link in tqdm.tqdm(docs_link):
-        # Initialize an APIReferenceLoader with the option to scrape visible content
-        loader = APIReferenceLoader(link, is_visible_scrape=True)
-        # Load the raw documents
-        raw_documents = loader.load()
-        # Initialize text splitters for documents and summaries
-        text_splitter = TokenTextSplitter(chunk_size=1200, chunk_overlap=150)
-        text_splitter_sum = TokenTextSplitter(chunk_size=3100, chunk_overlap=300)
-        # Split documents for summary and document lists
-        if return_summary:
-            docs_for_summary.extend(text_splitter_sum.split_documents(raw_documents))
-        documents.extend(text_splitter.split_documents(raw_documents))
+        try:
+            logging.info(link)
+            # Initialize an APIReferenceLoader with the option to scrape visible content
+            loader = APIReferenceLoader(link, is_visible_scrape=True)
+            # Load the raw documents
+            raw_documents = loader.load()
+            # Initialize text splitters for documents and summaries
+            text_splitter = TokenTextSplitter(chunk_size=1200, chunk_overlap=150)
+            text_splitter_sum = TokenTextSplitter(chunk_size=3100, chunk_overlap=300)
+            # Split documents for summary and document lists
+            if return_summary:
+                docs_for_summary.extend(text_splitter_sum.split_documents(raw_documents))
+            documents.extend(text_splitter.split_documents(raw_documents))
+        except Exception as e:
+            logging.warning("Failed to scrape {}".format(link))
+            logging.warning(e)
     logger.info("Number of documents: {}".format(len(documents)))
     
     logger.info("Saving vectorstore into assets/vectorstore.pkl")
@@ -314,6 +322,8 @@ class IngestDocumentsTask(luigi.Task):
     url_docs = luigi.Parameter()
     recursive_depth = luigi.IntParameter(default=1)
     logger = logging.getLogger(__name__)
+    retry_count = 5
+    retry_delay = 10
 
     def output(self):
         return {
@@ -352,6 +362,25 @@ class SaveVectorStoreTask(luigi.Task):
         with self.output().open("wb") as f:
             pickle.dump(vectorstore, f)
 
+class IngestDocs(luigi.Task):
+    url_docs = luigi.Parameter()
+    recursive_depth = luigi.IntParameter(default=1)
+
+    def requires(self):
+        return {
+            'ingest': IngestDocumentsTask(url_docs=self.url_docs, recursive_depth=self.recursive_depth),
+            'save': SaveVectorStoreTask(url_docs=self.url_docs, recursive_depth=self.recursive_depth)
+        }
+
+    def run(self):
+        pass  
+
+    def output(self):
+        return self.input()  
+
 
 if __name__ == "__main__":
-    luigi.build([SaveVectorStoreTask("https://developers.notion.com/reference/create-a-token", recursive_depth=0)], local_scheduler=True)
+    luigi.build(
+	[IngestDocs("https://developers.notion.com/reference", recursive_depth=1)],
+	local_scheduler=True,
+    )

--- a/ingest_docs.py
+++ b/ingest_docs.py
@@ -317,8 +317,8 @@ class IngestDocumentsTask(luigi.Task):
 
     def output(self):
         return {
-                'documents': luigi.LocalTarget("assets/documents_{}.pkl".format(self.task_id)),
-                'docs_for_summary': luigi.LocalTarget("assets/docs_for_summary_{}.pkl".format(self.task_id))
+                'documents': luigi.LocalTarget("assets/documents_{}.pkl".format(self.task_id), format=luigi.format.Nop),
+                'docs_for_summary': luigi.LocalTarget("assets/docs_for_summary_{}.pkl".format(self.task_id), format=luigi.format.Nop)
                 } 
 
     def run(self):
@@ -333,16 +333,17 @@ class IngestDocumentsTask(luigi.Task):
 
 @inherits(IngestDocumentsTask)
 class SaveVectorStoreTask(luigi.Task):
+    logger = logging.getLogger(__name__)
 
     def requires(self):
         return self.clone(IngestDocumentsTask)
 
     def output(self):
-        return luigi.LocalTarget("assets/vectorstore_{}.pkl".format(self.task_id))
-
+        return luigi.LocalTarget("assets/vectorstore_{}.pkl".format(self.task_id), format=luigi.format.Nop)
+                
     def run(self):
         self.logger.info(self.task_id)
-        with self.input()[0].open("rb") as f:
+        with self.input()['documents'].open("rb") as f:
             docs = pickle.load(f)
 
         embeddings = OpenAIEmbeddings()


### PR DESCRIPTION
Currently **the scraping task fails on half of the links** (e.g. 26 docs over 56 succesfully scraped for Notion APIs).
This means `main.py` will often fail on the scraping step without being able to continue the workflow.

This PR improves reliability by
1. onboarding `ingest_docs.py` and `data_gen.py` to https://github.com/spotify/luigi workflow management library, so tasks can be run independently and at different times/on different machines
2. adds try catch on Selenium exceptions so scraping can succeed even if partial

## Test Plan
```
(sheep-tutor) root@C.6209776:~/llamaacademy/assets$ python ingest_docs.py
...
===== Luigi Execution Summary =====

Scheduled 3 tasks of which:
* 3 ran successfully:
    - 1 IngestDocs(url_docs=https://developers.notion.com/reference, recursive_depth=1)
    - 1 IngestDocumentsTask(url_docs=https://developers.notion.com/reference, recursive_depth=1)
    - 1 SaveVectorStoreTask(url_docs=https://developers.notion.com/reference, recursive_depth=1)


(sheep-tutor) root@C.6209776:~/llamaacademy/assets$ find . -type f -name "*_0a560f2ee1*"
./documents_IngestDocumentsTask_1_https___develope_0a560f2ee1.pkl
./docs_for_summary_IngestDocumentsTask_1_https___develope_0a560f2ee1.pkl
./vectorstore_SaveVectorStoreTask_1_https___develope_0a560f2ee1.pkl
```